### PR TITLE
103 - Failing D8

### DIFF
--- a/arcgis-android-toolkit/build.gradle
+++ b/arcgis-android-toolkit/build.gradle
@@ -20,7 +20,7 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {
@@ -61,6 +61,8 @@ dependencies {
     api "android.arch.lifecycle:common-java8:$droid.lifecycle"
     api "com.google.ar.sceneform.ux:sceneform-ux:$droid.arCore"
     api "com.google.ar.sceneform:core:$droid.arCore"
+    // fixing failing D8 https://github.com/google-ar/sceneform-android-sdk/issues/575
+    implementation "com.google.ar.sceneform:animation:$droid.arCore"
     api "com.esri.arcgisruntime:arcgis-android:$arcgis"
     testImplementation "junit:junit:$test.jUnit"
     androidTestImplementation("com.android.support.test.espresso:espresso-core:$test.espresso", {

--- a/toolkit-test-app/build.gradle
+++ b/toolkit-test-app/build.gradle
@@ -21,7 +21,7 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {


### PR DESCRIPTION
Build failure can be found here: https://runtime-build-ssl.esri.com/job/100.6.0/job/daily_android_java_APP_toolkit/26/console