### PR TITLE
QAR-202 ArcGISArView behavioural and API changes

### DIFF
--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -253,9 +253,6 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
         set(value) {
             field = value
             cameraController.originCamera = value
-            if (isTracking) {
-                resetTracking()
-            }
         }
 
     /**

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -149,7 +149,6 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
     private val identityMatrix: TransformationMatrix = TransformationMatrix.createIdentityMatrix()
 
     /**
-     * The camera controller used to control the camera that is used in [arcGisSceneView].
      * Initial [TransformationMatrix] used by [cameraController].
      *
      * @since 100.6.0

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -155,11 +155,8 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      *
      * @since 100.6.0
      */
-    var cameraController: TransformationMatrixCameraController =
+    private var cameraController: TransformationMatrixCameraController =
         TransformationMatrixCameraController()
-        private set(value) {
-            field = value
-        }
 
     /**
      * Device Orientation to be used when setting Field of View. Default is [DeviceOrientation.PORTRAIT].

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -253,8 +253,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      * location updates.
      *
      * Upon receiving an updated location, if we don't previously have an [originCamera] we use the new location to
-     * create a [Camera] and set that as the origin camera of the [cameraController]. On every other location update, if we
-     * are not using ARCore we create a new Camera using properties of the old camera. If user is using ARCore we reset
+     * create a [Camera] and set that as the origin camera of the [cameraController]. If user is using ARCore we reset
      * the session to correct the tracking. We also reset the TransformationMatrix of the CameraController and stop the
      * [locationDataSource] if [useLocationDataSourceOnce] is true.
      *

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -514,15 +514,8 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
         // permission on Android M and above, now is a good time to ask the user for it.
         // when the permission is requested and the user responds to the request from the OS this is executed again
         // during onResume()
-        if (isUsingARCore == ARCoreUsage.YES && renderVideoFeed && !hasPermission(
-                CAMERA_PERMISSION
-            )
-        ) {
-            requestPermission(
-                context as Activity,
-                CAMERA_PERMISSION,
-                CAMERA_PERMISSION_CODE
-            )
+        if (isUsingARCore == ARCoreUsage.YES && renderVideoFeed && !hasPermission(CAMERA_PERMISSION)) {
+            requestPermission(context as Activity, CAMERA_PERMISSION, CAMERA_PERMISSION_CODE)
             return
         }
 

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -533,8 +533,8 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
     fun resetTracking() {
         originCamera = null
         initialTransformationMatrix = identityMatrix
-        cameraController.transformationMatrix = identityMatrix
         startTracking(false)
+        cameraController.transformationMatrix = identityMatrix
     }
 
     /**

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -243,6 +243,13 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
         }
 
     /**
+     * Property to determine if we are using only the first location provided by the LocationDataSource
+     *
+     * @since 100.6.0
+     */
+    private var useLocationDataSourceOnce: Boolean = true
+
+    /**
      * This listener is added to every [LocationDataSource] used when using the [locationDataSource] property to receive
      * location updates.
      *
@@ -274,6 +281,10 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
 
                 // Reset the camera controller's transformationMatrix to its initial state, the identity matrix.
                 cameraController.transformationMatrix = identityMatrix
+
+                if (useLocationDataSourceOnce) {
+                    locationDataSource?.stop()
+                }
             }
         }
 
@@ -468,11 +479,12 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      * @since 100.6.0
      */
     @SuppressLint("MissingPermission") // suppressed as function returns if permission hasn't been granted
-    fun startTracking() {
-        startTracking(true)
+    fun startTracking(useLocationDataSourceOnce: Boolean) {
+        this.useLocationDataSourceOnce = useLocationDataSourceOnce
+        internalStartTracking(true)
     }
 
-    private fun startTracking(restartLocationDataSource: Boolean = true) {
+    private fun internalStartTracking(restartLocationDataSource: Boolean = true) {
         (context as? Activity)?.let { activity ->
             // ARCore requires camera permissions to operate. If we did not yet obtain runtime
             // permission on Android M and above, now is a good time to ask the user for it.
@@ -550,7 +562,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
     fun resetTracking() {
         originCamera = null
         initialTransformationMatrix = identityMatrix
-        startTracking(false)
+        internalStartTracking(false)
         cameraController.transformationMatrix = identityMatrix
     }
 

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -161,7 +161,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      *
      * @since 100.6.0
      */
-    private var cameraController: TransformationMatrixCameraController =
+    private val cameraController: TransformationMatrixCameraController =
         TransformationMatrixCameraController()
 
     /**

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -265,13 +265,11 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
                 // Always set the origin camera; then reset ARCore
                 val oldCamera = cameraController.originCamera
 
-                // Create a new camera based on our location and set it on the cameraController.
-                if (originCamera == null) {
-                    val newCamera = Camera(location, 0.0, 90.0, 0.0)
-                    originCamera = newCamera
+                // Create a new camera based on our location and set it on the originCamera.
+                originCamera = if (originCamera == null) {
+                    Camera(location, 0.0, 90.0, 0.0)
                 } else {
-                    cameraController.originCamera =
-                        Camera(location, oldCamera.heading, oldCamera.pitch, oldCamera.roll)
+                    Camera(location, oldCamera.heading, oldCamera.pitch, oldCamera.roll)
                 }
 
                 // If we're using ARCore, reset the session.

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -255,7 +255,9 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      *
      * Upon receiving an updated location, if we don't previously have an [originCamera] we use the new location to
      * create a [Camera] and set that as the origin camera of the [cameraController]. On every other location update, if we
-     * are not using ARCore we set the current viewpoint camera of [sceneView] to a new Camera created from that location.
+     * are not using ARCore we create a new Camera using properties of the old camera. If user is using ARCore we reset
+     * the session to correct the tracking. We also reset the TransformationMatrix of the CameraController and stop the
+     * [locationDataSource] if [useLocationDataSourceOnce] is true.
      *
      * @since 100.6.0
      */

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -526,7 +526,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
     }
 
     /**
-     * Resets the [originCamera] and starts tracking.
+     * Resets the device tracking and related properties.
      *
      * @since 100.6.0
      */

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -176,8 +176,11 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      *
      * @since 100.6.0
      */
-    private val cameraController: TransformationMatrixCameraController =
+    var cameraController: TransformationMatrixCameraController =
         TransformationMatrixCameraController()
+        private set(value) {
+            field = value
+        }
 
     /**
      * Device Orientation to be used when setting Field of View. Default is [DeviceOrientation.PORTRAIT].

--- a/toolkit-test-app/src/main/java/com/esri/arcgisruntime/toolkit/test/ar/ArcGISArViewActivity.kt
+++ b/toolkit-test-app/src/main/java/com/esri/arcgisruntime/toolkit/test/ar/ArcGISArViewActivity.kt
@@ -49,9 +49,9 @@ import kotlinx.android.synthetic.main.activity_ar_arcgissceneview.arcGisArView
 class ArcGISArViewActivity : AppCompatActivity() {
 
     private val androidLocationDataSource: LocationDataSource
-    get() {
-        return AndroidLocationDataSource(this)
-    }
+        get() {
+            return AndroidLocationDataSource(this)
+        }
 
     /**
      * AR Mode: Full-Scale AR
@@ -97,7 +97,7 @@ class ArcGISArViewActivity : AppCompatActivity() {
 
                     if (extent != null) {
                         val center = extent.center
-                        val camera = Camera(center, 0.0, 0.0, 0.0)
+                        val camera = Camera(center, 0.0, 90.0, 0.0)
                         arcGisArView.originCamera = camera
                         arcGisArView.translationTransformationFactor = 2000.0
                     }
@@ -161,7 +161,7 @@ class ArcGISArViewActivity : AppCompatActivity() {
                                 center.x,
                                 elevation,
                                 0.0,
-                                0.0,
+                                90.0,
                                 0.0
                             )
                             arcGisArView.originCamera = camera
@@ -224,7 +224,7 @@ class ArcGISArViewActivity : AppCompatActivity() {
                                 center.x,
                                 elevation,
                                 0.0,
-                                0.0,
+                                90.0,
                                 0.0
                             )
                             arcGisArView.originCamera = camera
@@ -249,7 +249,7 @@ class ArcGISArViewActivity : AppCompatActivity() {
                 addElevationSource(this)
 
                 arcGisArView.locationDataSource = androidLocationDataSource
-                arcGisArView.originCamera = Camera(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+                arcGisArView.originCamera = Camera(0.0, 0.0, 0.0, 0.0, 90.0, 0.0)
                 arcGisArView.translationTransformationFactor = 1.0
             }
         }
@@ -265,7 +265,7 @@ class ArcGISArViewActivity : AppCompatActivity() {
         return {
             ArcGISScene("http://www.arcgis.com/home/webscene/viewer.html?webscene=d406d82dbc714d5da146d15b024e8d33").apply {
                 arcGisArView.locationDataSource = androidLocationDataSource
-                arcGisArView.originCamera = Camera(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+                arcGisArView.originCamera = Camera(0.0, 0.0, 0.0, 0.0, 90.0, 0.0)
                 arcGisArView.translationTransformationFactor = 1.0
             }
         }
@@ -278,7 +278,10 @@ class ArcGISArViewActivity : AppCompatActivity() {
             SceneInfo(yosemiteScene(), getString(R.string.arcgis_ar_view_scene_yosemite)),
             SceneInfo(borderScene(), getString(R.string.arcgis_ar_view_scene_border)),
             SceneInfo(emptyScene(), getString(R.string.arcgis_ar_view_scene_empty)),
-            SceneInfo(redlandsFireHydrantsScene(), getString(R.string.arcgis_ar_view_redlands_fire_hydrants))
+            SceneInfo(
+                redlandsFireHydrantsScene(),
+                getString(R.string.arcgis_ar_view_redlands_fire_hydrants)
+            )
         )
     }
 
@@ -295,7 +298,8 @@ class ArcGISArViewActivity : AppCompatActivity() {
         arcGisArView.registerLifecycle(lifecycle)
         currentScene = scenes[0]
 
-        arcGisArView.sceneView.setOnTouchListener(object : DefaultSceneViewOnTouchListener(arcGisArView.sceneView) {
+        arcGisArView.sceneView.setOnTouchListener(object :
+            DefaultSceneViewOnTouchListener(arcGisArView.sceneView) {
             override fun onSingleTapConfirmed(motionEvent: MotionEvent?): Boolean {
                 motionEvent?.let {
                     with(Point(motionEvent.x.toInt(), motionEvent.y.toInt())) {


### PR DESCRIPTION
Feature issue: https://devtopia.esri.com/runtime/queen-annes-revenge/issues/202

A number of changes are occurring in this PR:

- Changes to location handling
- Moved starting of ARCore and LocationDataSource to separate functions to allow independent starting/stopping/resetting
- Removed compensation Quaternion as it's no longer required so long as the user sets the pitch of the initial camera to `90.0`