### PR TITLE
QAR-213 - Initial heading is not reset when tracking is reset

### DIFF
--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -640,6 +640,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
     fun resetTracking() {
         didSetInitialLocation = false
         originCamera = null
+        initialHeading = null
         initialTransformationMatrix = identityMatrix
         if (isUsingARCore == ARCoreUsage.YES) {
             startArCoreSession()


### PR DESCRIPTION
https://devtopia.esri.com/runtime/queen-annes-revenge/issues/213

Resetting initial heading when resetting tracking.