### PR TITLE
QAR-212 AR scene view pause issue

### DIFF
--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -308,11 +308,6 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
                         )
                 }
 
-                // If we're using ARCore, reset the session.
-                if (isUsingARCore == ARCoreUsage.YES) {
-                    startArCoreSession()
-                }
-
                 if (arLocationTrackingMode != ARLocationTrackingMode.CONTINUOUS) {
                     locationDataSource?.stop()
                 }
@@ -580,7 +575,9 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
         }
 
         if (isUsingARCore == ARCoreUsage.YES) {
-            arSceneView?.scene?.addOnUpdateListener(this)
+            arSceneView?.scene?.let { scene ->
+                post { scene.addOnUpdateListener(this) }
+            }
             try {
                 arSceneView?.resume()
             } catch (e: Exception) {
@@ -627,7 +624,12 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      * @since 100.6.0
      */
     fun stopTracking() {
-        arSceneView?.pause()
+        arSceneView?.let {
+            it.scene?.let { scene ->
+                post { scene.removeOnUpdateListener(this) }
+            }
+            it.pause()
+        }
         locationDataSource?.stop()
         isTracking = false
     }

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -308,6 +308,11 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
                         )
                 }
 
+                // If we're using ARCore, reset the session.
+                if (isUsingARCore == ARCoreUsage.YES) {
+                    startArCoreSession()
+                }
+
                 if (arLocationTrackingMode != ARLocationTrackingMode.CONTINUOUS) {
                     locationDataSource?.stop()
                 }

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -576,6 +576,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
 
         if (isUsingARCore == ARCoreUsage.YES) {
             arSceneView?.scene?.let { scene ->
+                // ensure that OnUpdateListener is added on the UI thread to prevent threading issues with ARCore
                 post { scene.addOnUpdateListener(this) }
             }
             try {
@@ -626,6 +627,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
     fun stopTracking() {
         arSceneView?.let {
             it.scene?.let { scene ->
+                // ensure that OnUpdateListener is removed on the UI thread to prevent threading issues with ARCore
                 post { scene.removeOnUpdateListener(this) }
             }
             it.pause()


### PR DESCRIPTION
https://devtopia.esri.com/runtime/queen-annes-revenge/issues/212

PO had reported issues with Pixel 3 when Activity was paused and resumed. Repro'd on OnePlus 7 Pro and Moto G6 Plus.

I isolated the issue to the use of the `OnUpdateListener` and I believe that since ARCore is almost entirely run on the UI thread, adding / removing an `OnUpdateListener` on a separate thread causes the issue.

I have moved the adding/removing to inside Runnables that are posted on the UI thread and it appears to fix the issue.