### PR TITLE
131 - make istracking setter private

### DIFF
--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -153,7 +153,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      *
      * @since 100.6.0
      */
-    var initialTransformationMatrix: TransformationMatrix = identityMatrix
+    private var initialTransformationMatrix: TransformationMatrix = identityMatrix
 
     /**
      * The camera controller used to control the camera that is used in [arcGisSceneView].

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -224,6 +224,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      * @since 100.6.0
      */
     var arSceneView: ArSceneView? = null
+        private set
         get() = _arSceneView
 
     /**
@@ -400,6 +401,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      * @since 100.6.0
      */
     var isTracking: Boolean = false
+        private set
 
     /**
      * Denotes whether ARCore is being used to track location and angles.
@@ -407,7 +409,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      * @since 100.6.0
      */
     var isUsingARCore: ARCoreUsage = ARCoreUsage.UNKNOWN
-        set(value) {
+        private set(value) {
             field = value
             sceneView.isManualRenderingEnabled = value == ARCoreUsage.YES
         }
@@ -431,6 +433,7 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      * @since 100.6.0
      */
     var error: Exception? = null
+        private set
 
     /**
      * Constructor used when instantiating this View directly to attach it to another view programmatically.


### PR DESCRIPTION
https://github.com/Esri/arcgis-runtime-toolkit-android/issues/131

I have changed the visibility of the setter of the following properties to prevent a client making changes to the value of these properties:
- arSceneView
- isTracking
- isUsingARCore
- error

Setting `initialTransformationMatrix` as private as there is a function to set the `initialTransformationMatrix` property from an `android.graphics.Point` instance:

```
fun setInitialTransformationMatrix(screenPoint: android.graphics.Point): Boolean
```