### PR TITLE
QAR - 207 - Revamp originCamera property

### DIFF
--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -233,12 +233,10 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      *
      * @since 100.6.0
      */
-    var originCamera: Camera? = null
+    var originCamera: Camera = cameraController.originCamera
         set(value) {
             field = value
-            if (value != null) {
-                cameraController.originCamera = value
-            }
+            cameraController.originCamera = value
         }
 
     /**
@@ -643,7 +641,6 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
      */
     fun resetTracking() {
         didSetInitialLocation = false
-        originCamera = null
         initialHeading = null
         initialTransformationMatrix = identityMatrix
         if (isUsingARCore == ARCoreUsage.YES) {


### PR DESCRIPTION
https://devtopia.esri.com/runtime/queen-annes-revenge/issues/207

Revamped origin camera to be non-null:
- Getting origin camera from camera controller and when setting, setting it against camera controller.