### PR TITLE
135 - call reset tracking when start tracking

### DIFF
--- a/toolkit-test-app/src/main/java/com/esri/arcgisruntime/toolkit/test/ar/ArcGISArViewActivity.kt
+++ b/toolkit-test-app/src/main/java/com/esri/arcgisruntime/toolkit/test/ar/ArcGISArViewActivity.kt
@@ -314,6 +314,8 @@ class ArcGISArViewActivity : AppCompatActivity() {
                 title = it.name
                 calibrating = calibrating.and(it.isTabletop.not())
                 invalidateOptionsMenu()
+                arcGisArView.resetTracking()
+                arcGisArView.startTracking(it.locationTrackingMode)
             }
         }
 


### PR DESCRIPTION
https://github.com/Esri/arcgis-runtime-toolkit-android/issues/135

Calling startTracking after selecting scene and calling resetTracking before startTracking to reset initial properties.