### PR TITLE
Feature/clipping distance

### DIFF
--- a/arcgis-android-toolkit/src/androidTest/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArViewTest.kt
+++ b/arcgis-android-toolkit/src/androidTest/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArViewTest.kt
@@ -189,7 +189,7 @@ class ArcGISArViewTest {
                 it?.clippingDistance = clippingDistance
 
                 assertEquals(
-                        "Expected translation transformation factor $clippingDistance",
+                        "Expected clipping distance $clippingDistance",
                         clippingDistance,
                         it?.clippingDistance
                 )

--- a/arcgis-android-toolkit/src/androidTest/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArViewTest.kt
+++ b/arcgis-android-toolkit/src/androidTest/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArViewTest.kt
@@ -174,4 +174,28 @@ class ArcGISArViewTest {
         }
     }
 
+    /**
+     * Tests setting the [ArcGISArView.clippingDistance] property.
+     *
+     * @since 100.6.0
+     */
+    @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.N)
+    fun testClippingDistance() {
+        val clippingDistance = 99.9
+        with(arcGisArViewTestActivityRule) {
+            this.launchActivity()
+            this.activity.arcGISArView.let {
+                it?.clippingDistance = clippingDistance
+
+                assertEquals(
+                        "Expected translation transformation factor $clippingDistance",
+                        clippingDistance,
+                        it?.clippingDistance
+                )
+            }
+            this.finish()
+        }
+    }
+
 }

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/ar/ArcGISArView.kt
@@ -434,6 +434,19 @@ class ArcGISArView : FrameLayout, DefaultLifecycleObserver, Scene.OnUpdateListen
         ArrayList<String>()
     }
 
+	/**
+     * Determines the clipping distance around the originCamera. The units are meters; the default is 0.0.
+     * When the value is set to 0.0 there is no enforced clipping distance. Setting the value to 10.0 will
+     * only render data 10 meters around the originCamera.
+     *
+     * @since 100.7.0
+     */
+    var clippingDistance: Double
+        get() = cameraController.clippingDistance
+        set(value) {
+            cameraController.clippingDistance = value
+        }
+
     /**
      * Exposes an [Exception] should it occur when using this view.
      *

--- a/gradle/script/versions.gradle
+++ b/gradle/script/versions.gradle
@@ -35,5 +35,5 @@ ext {
     }
     kotlin_version = "1.3.41"
     kotlin_coroutines = "1.3.0-RC"
-    arcgis = "100.7.0-2611"
+    arcgis = "100.7.0"
 }

--- a/gradle/script/versions.gradle
+++ b/gradle/script/versions.gradle
@@ -35,5 +35,5 @@ ext {
     }
     kotlin_version = "1.3.41"
     kotlin_coroutines = "1.3.0-RC"
-    arcgis = "100.6.0"
+    arcgis = "100.7.0-2611"
 }

--- a/toolkit-test-app/src/main/java/com/esri/arcgisruntime/toolkit/test/ar/ArcGISArViewActivity.kt
+++ b/toolkit-test-app/src/main/java/com/esri/arcgisruntime/toolkit/test/ar/ArcGISArViewActivity.kt
@@ -130,6 +130,8 @@ class ArcGISArViewActivity : AppCompatActivity() {
                         val camera = Camera(center, 0.0, 90.0, 0.0)
                         arcGisArView.originCamera = camera
                         arcGisArView.translationFactor = 2000.0
+                        // Set the clipping distance to limit the data display around the originCamera.
+                        arcGisArView.clippingDistance = 750.0
                     }
                 }
 
@@ -259,6 +261,9 @@ class ArcGISArViewActivity : AppCompatActivity() {
                             )
                             arcGisArView.originCamera = camera
                             arcGisArView.translationFactor = 1000.0
+
+                            // Set the clipping distance to limit the data display around the originCamera.
+                            arcGisArView.clippingDistance = 500.0
                         }
                     }
                 }

--- a/toolkit-test-app/src/main/java/com/esri/arcgisruntime/toolkit/test/ar/ArcGISArViewActivity.kt
+++ b/toolkit-test-app/src/main/java/com/esri/arcgisruntime/toolkit/test/ar/ArcGISArViewActivity.kt
@@ -261,7 +261,6 @@ class ArcGISArViewActivity : AppCompatActivity() {
                             )
                             arcGisArView.originCamera = camera
                             arcGisArView.translationFactor = 1000.0
-
                             // Set the clipping distance to limit the data display around the originCamera.
                             arcGisArView.clippingDistance = 500.0
                         }


### PR DESCRIPTION
This PR exposes the TransformationMatrixCameraController.clippingDistance property that is being added in the Runtime 100.7.0 release. 

I tried to keep this PR consistent with what the iOS toolkit did https://github.com/Esri/arcgis-runtime-toolkit-ios/pull/85

Also just to be clear, the clippingDistance property cannot be changed by RTC like translationFactor or orginCamera