### PR TITLE
fixes the upside down scale bar with the secondary tick on top

### DIFF
--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/Scalebar.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/Scalebar.kt
@@ -481,7 +481,9 @@ class Scalebar : View {
             }
 
             val top: Float = when (style) {
-                Style.DUAL_UNIT_LINE -> if (drawInMapView) bottom - DEFAULT_BAR_HEIGHT_DP.dpToPixels(displayDensity).toFloat() - textSize - maxPixelsBelowBaseline else 0.0f
+                Style.DUAL_UNIT_LINE -> if (drawInMapView) bottom - DEFAULT_BAR_HEIGHT_DP.dpToPixels(
+                    displayDensity
+                ).toFloat() - textSize - maxPixelsBelowBaseline else 0.0f
                 else -> if (drawInMapView) bottom - DEFAULT_BAR_HEIGHT_DP.dpToPixels(displayDensity).toFloat() else 0.0f
             }
 

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/Scalebar.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/Scalebar.kt
@@ -480,8 +480,10 @@ class Scalebar : View {
                 height.toFloat() - textSize - maxPixelsBelowBaseline
             }
 
-            val top: Float =
-                if (drawInMapView) bottom - DEFAULT_BAR_HEIGHT_DP.dpToPixels(displayDensity).toFloat() else 0.0f
+            val top: Float = when (style.value) {
+                Style.DUAL_UNIT_LINE.value -> if (drawInMapView) bottom - DEFAULT_BAR_HEIGHT_DP.dpToPixels(displayDensity).toFloat() - textSize - maxPixelsBelowBaseline else 0.0f
+                else -> if (drawInMapView) bottom - DEFAULT_BAR_HEIGHT_DP.dpToPixels(displayDensity).toFloat() else 0.0f
+            }
 
             // Draw the scalebar
             style.renderer.drawScalebar(

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/Scalebar.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/Scalebar.kt
@@ -480,8 +480,8 @@ class Scalebar : View {
                 height.toFloat() - textSize - maxPixelsBelowBaseline
             }
 
-            val top: Float = when (style.value) {
-                Style.DUAL_UNIT_LINE.value -> if (drawInMapView) bottom - DEFAULT_BAR_HEIGHT_DP.dpToPixels(displayDensity).toFloat() - textSize - maxPixelsBelowBaseline else 0.0f
+            val top: Float = when (style) {
+                Style.DUAL_UNIT_LINE -> if (drawInMapView) bottom - DEFAULT_BAR_HEIGHT_DP.dpToPixels(displayDensity).toFloat() - textSize - maxPixelsBelowBaseline else 0.0f
                 else -> if (drawInMapView) bottom - DEFAULT_BAR_HEIGHT_DP.dpToPixels(displayDensity).toFloat() else 0.0f
             }
 

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/style/renderer/DualUnitLineRenderer.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/style/renderer/DualUnitLineRenderer.kt
@@ -78,7 +78,7 @@ class DualUnitLineRenderer : ScalebarRenderer() {
             secondaryUnitsLength = secondaryBaseUnits.convertTo(secondaryDisplayUnits, secondaryUnitsLength)
         }
 
-        val verticalTextSpace = textSizePx + textPaint.fontMetrics.bottom
+        val verticalTextSpace = textSizePx + textPaint.fontMetrics.top
 
         // Create Paint for drawing the lines
         with(paint) {
@@ -114,7 +114,7 @@ class DualUnitLineRenderer : ScalebarRenderer() {
                 canvas.drawPath(linePath, this)
 
                 // Draw the primary units label above the tick at the right hand end
-                var yPosText = top + textSizePx
+                var yPosText = top
                 textPaint.textAlign = Paint.Align.RIGHT
                 canvas.drawText(distance.asDistanceString(), right, yPosText, textPaint)
                 textPaint.textAlign = Paint.Align.LEFT

--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/style/renderer/DualUnitLineRenderer.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/style/renderer/DualUnitLineRenderer.kt
@@ -78,7 +78,7 @@ class DualUnitLineRenderer : ScalebarRenderer() {
             secondaryUnitsLength = secondaryBaseUnits.convertTo(secondaryDisplayUnits, secondaryUnitsLength)
         }
 
-        val verticalTextSpace = textSizePx + textPaint.fontMetrics.top
+        val verticalTextSpace = textSizePx + textPaint.fontMetrics.bottom
 
         // Create Paint for drawing the lines
         with(paint) {
@@ -114,7 +114,7 @@ class DualUnitLineRenderer : ScalebarRenderer() {
                 canvas.drawPath(linePath, this)
 
                 // Draw the primary units label above the tick at the right hand end
-                var yPosText = top
+                var yPosText = top + textSizePx
                 textPaint.textAlign = Paint.Align.RIGHT
                 canvas.drawText(distance.asDistanceString(), right, yPosText, textPaint)
                 textPaint.textAlign = Paint.Align.LEFT


### PR DESCRIPTION
- fix the upside down scale bar with the secondary tick on top
- position primary distance and unit in correct location

before - 

<img width="411" alt="Screen Shot 2020-02-24 at 8 45 12 PM" src="https://user-images.githubusercontent.com/5582469/75215766-9ce80500-5746-11ea-854c-6a0667abdd2e.png">

with the fix:

<img width="421" alt="Screen Shot 2020-02-24 at 8 35 53 PM" src="https://user-images.githubusercontent.com/5582469/75215532-e552f300-5745-11ea-9e68-a954338d0256.png">
