### PR TITLE
Issue/puneet/scalebar fix insetoverlaps scalebar

### DIFF
--- a/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/Scalebar.kt
+++ b/arcgis-android-toolkit/src/main/java/com/esri/arcgisruntime/toolkit/scalebar/Scalebar.kt
@@ -541,13 +541,13 @@ class Scalebar : View {
      */
     private fun calculateLeftPos(alignment: Alignment, scalebarLength: Float, displayUnits: LinearUnit): Float {
         var left = 0
-        val right = width
+        var right = width
         // padding to ensure the lines at the ends fit within the view
         var padding = lineWidthDp.dpToPixels(displayDensity)
         if (drawInMapView) {
             mapView?.let { mapView ->
                 left = mapView.viewInsetLeft.dpToPixels(displayDensity)
-                right.minus(mapView.viewInsetRight.dpToPixels(displayDensity))
+                right = right.minus(mapView.viewInsetRight.dpToPixels(displayDensity))
                 padding = SCALEBAR_X_PAD_DP.dpToPixels(displayDensity)
             }
         }


### PR DESCRIPTION
When calculating the anchor position the right position of the scalebar was not getting altered as the variable was defined a `val` and not a `var` . Also missing was the assignment of the new value.
The commit addresses both and Scalebar displays as expected with insets on the MapView