### PR TITLE
update toolkit version 100.8.0

### DIFF
--- a/gradle/script/versions.gradle
+++ b/gradle/script/versions.gradle
@@ -39,5 +39,5 @@ ext {
     }
     kotlin_version = "1.3.41"
     kotlin_coroutines = "1.3.0-RC"
-    arcgis = "100.8.0-2727"
+    arcgis = "100.8.0"
 }


### PR DESCRIPTION
@gunt0001 @eri9600 please review. This removes the build number from the 100.8.0 version. 

https://devtopia.esri.com/runtime/java/issues/2728