### PR TITLE
update toolkit kotlin plugins and heapsize

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
-# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/gradle/script/versions.gradle
+++ b/gradle/script/versions.gradle
@@ -39,5 +39,5 @@ ext {
     }
     kotlin_version = "1.3.41"
     kotlin_coroutines = "1.3.0-RC"
-    arcgis = "100.8.0-2727"
+    arcgis = "100.8.0"
 }

--- a/toolkit-test-app/build.gradle
+++ b/toolkit-test-app/build.gradle
@@ -16,8 +16,9 @@
 
 plugins {
     id 'com.android.application'
-    id 'kotlin-android-extensions'
     id 'kotlin-android'
+    id 'kotlin-android-extensions'
+    id 'kotlin-kapt'
     id 'org.jetbrains.dokka-android'
 }
 


### PR DESCRIPTION
@alan-edi @gunt0001 please review.

This PR addresses the things the compiler was complaining about,
1. we are missing the Kotlin-kapt plugin(required for data binding) in the test project. also the Kotlin-android plugin should be included before the Kotlin-android-extenstions.

Also,
added JVM arguments to gradle.properties as the project runs out of memory and fails to compile without it.