### PR TITLE
fix broken link

### DIFF
--- a/Documentation/setup.md
+++ b/Documentation/setup.md
@@ -11,7 +11,7 @@ To use the ArcGIS Runtime Toolkit for Android, first you need an app that uses t
 
 You can add toolkit components which complement the functionality of the ArcGIS Runtime SDK for Android into your own applications.  For example the toolkit allows you to add components such as scale bars, north arrows, or augmented reality controls.
 
-The toolkit components are available as a library (.aar) in Bintray, or you can use the the source code for the toolkit directly from this repository.  Read the [read me](https://github.com/Esri/arcgis-runtime-toolkit-android/tree/100.6.0) instructions for using the compiled library.
+The toolkit components are available as a library (.aar) in Bintray, or you can use the the source code for the toolkit directly from this repository.  Read the [read me](https://github.com/Esri/arcgis-runtime-toolkit-android/blob/master/README.md) instructions for using the compiled library.
 
 ## Use the toolkit from source code
 


### PR DESCRIPTION
@alan-edi @gunt0001  This fixes the link to the readme. Please review.

>alan0001 May 15th at 4:40 AM
@pune6188 Just spotted a bug in the https://github.com/Esri/arcgis-runtime-toolkit-android/blob/master/Documentation/setup.md file. In the last sentence of the “Use the toolkit library” section there’s a link [read me](https://github.com/Esri/arcgis-runtime-toolkit-android/tree/100.6.0) which goes to an out of date destination (100.6.0).