### PR TITLE
update sceneform sdk for android to 1.17.1

### DIFF
--- a/gradle/script/versions.gradle
+++ b/gradle/script/versions.gradle
@@ -24,7 +24,7 @@ ext {
         constraintLayout = "1.1.3"
         multiDex = "2.0.1"
         testRunner = "1.2.0"
-        arCore = "1.17.0"
+        arCore = "1.17.1"
         lifecycle = "2.2.0"
         appcompat = "1.1.0"
         material = "1.1.0"


### PR DESCRIPTION
Fixes the crash on inflation of ArViews in the tookit because of a class missing exception ClassNotFoundException: Didn't find class "com.google.android.filament.gltfio.Gltfio"

The crash is happening because of the Sceneform SDK for Android version 1.17.0 . We upgraded to it after we updated the version of the dependencies after we released 100.8 . Unfortunately the project has been achieved and no longer maintained. The recommendation is to use 1.17.1 which is identical to version 1.15.0 (details in README.md) .
I am spinning up a pr to update the version to 1.17.1 which fixes the issue.
https://developers.google.com/sceneform/develop/ 