### PR TITLE
Update bintray references

### DIFF
--- a/Documentation/setup.md
+++ b/Documentation/setup.md
@@ -11,7 +11,7 @@ To use the ArcGIS Runtime Toolkit for Android, first you need an app that uses t
 
 You can add toolkit components which complement the functionality of the ArcGIS Runtime SDK for Android into your own applications.  For example the toolkit allows you to add components such as scale bars, north arrows, or augmented reality controls.
 
-The toolkit components are available as a library (.aar) in Jfrog, or you can use the the source code for the toolkit directly from this repository.  Read the [read me](https://github.com/Esri/arcgis-runtime-toolkit-android/blob/master/README.md) instructions for using the compiled library.
+The toolkit components are available as a library (.aar) in Jfrog, or you can use the source code for the toolkit directly from this repository.  Read the [read me](https://github.com/Esri/arcgis-runtime-toolkit-android/blob/master/README.md) instructions for using the compiled library.
 
 ## Use the toolkit from source code
 

--- a/Documentation/setup.md
+++ b/Documentation/setup.md
@@ -11,7 +11,7 @@ To use the ArcGIS Runtime Toolkit for Android, first you need an app that uses t
 
 You can add toolkit components which complement the functionality of the ArcGIS Runtime SDK for Android into your own applications.  For example the toolkit allows you to add components such as scale bars, north arrows, or augmented reality controls.
 
-The toolkit components are available as a library (.aar) in Bintray, or you can use the the source code for the toolkit directly from this repository.  Read the [read me](https://github.com/Esri/arcgis-runtime-toolkit-android/blob/master/README.md) instructions for using the compiled library.
+The toolkit components are available as a library (.aar) in Jfrog, or you can use the the source code for the toolkit directly from this repository.  Read the [read me](https://github.com/Esri/arcgis-runtime-toolkit-android/blob/master/README.md) instructions for using the compiled library.
 
 ## Use the toolkit from source code
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # ArcGIS Runtime Toolkit Android
 
-[![doc badge](https://img.shields.io/badge/Doc-purple)](Documentation) [![package badge](https://img.shields.io/bintray/v/esri/arcgis/arcgis-android-toolkit?color=limegreen)](https://bintray.com/esri/arcgis/arcgis-android-toolkit)
+[![doc badge](https://img.shields.io/badge/Doc-purple)](Documentation) 
 
 The ArcGIS Runtime Toolkit for Android contains views that you can use with [ArcGIS Runtime SDK for Android](https://developers.arcgis.com/android/).
 
 You can use the Toolkit in your projects by:
 
-1. **Reference from Bintray** - the fastest way to get toolkit into your app
-    * Ensure the Esri public Bintray Maven repository is in your project's gradle file - `https://esri.jfrog.io/artifactory/arcgis`
+1. **Reference from Jfrog** - the fastest way to get toolkit into your app
+    * Ensure the Esri public Jfrog Maven repository is in your project's gradle file - `https://esri.jfrog.io/artifactory/arcgis`
 
     ```
     allprojects {

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ The ArcGIS Runtime Toolkit for Android contains views that you can use with [Arc
 You can use the Toolkit in your projects by:
 
 1. **Reference from Bintray** - the fastest way to get toolkit into your app
-    * Ensure the Esri public Bintray Maven repository is in your project's gradle file - `https://esri.bintray.com/arcgis`
+    * Ensure the Esri public Bintray Maven repository is in your project's gradle file - `https://esri.jfrog.io/artifactory/arcgis`
 
     ```
     allprojects {
     	repositories {
     		...
-    		maven { url 'https://esri.bintray.com/arcgis' }
+    		maven { url 'https://esri.jfrog.io/artifactory/arcgis' }
     		...
     	}
     }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://esri.bintray.com/arcgis' }
+        maven { url 'https://esri.jfrog.io/artifactory/arcgis' }
         maven { url 'http://olympus.esri.com/artifactory/arcgisruntime-repo/' }
     }
 }


### PR DESCRIPTION
replaces the references to `https://esri.bintray.com/arcgis`

with

`https://esri.jfrog.io/artifactory/arcgis`