### PR TITLE
revert targetsdk version

### DIFF
--- a/gradle/script/versions.gradle
+++ b/gradle/script/versions.gradle
@@ -17,7 +17,7 @@
 ext {
     droid = ext {
         minSdk = 23
-        targetSdk = 31
+        targetSdk = 29
         androidGradlePlugin = "4.0.0"
         androidMavenGradlePlugin = "2.1"
         dokka = "0.9.18"


### PR DESCRIPTION
Reverts the targetSdk version for the toolkit test app and compileSdkVersion for the toolkit 
that breaks the build because of the now deprecated Kotlin-KAPT plugin version not working with version 31

https://github.com/Esri/arcgis-runtime-toolkit-android/pull/207/files