### PR TITLE
upgrade gradle plugin from 4.0.0 to 7.0.2

### DIFF
--- a/arcgis-android-toolkit/build.gradle
+++ b/arcgis-android-toolkit/build.gradle
@@ -48,11 +48,11 @@ android {
         debug {}
     }
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility 11
+        targetCompatibility 11
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     buildFeatures {
         dataBinding = true

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
         google()
         jcenter()
         maven { url 'https://esri.jfrog.io/artifactory/arcgis' }
-        maven { url 'http://olympus.esri.com/artifactory/arcgisruntime-repo/' }
+        maven { url 'https://olympus.esri.com/artifactory/arcgisruntime-repo/' }
     }
 }
 

--- a/gradle/script/versions.gradle
+++ b/gradle/script/versions.gradle
@@ -17,8 +17,8 @@
 ext {
     droid = ext {
         minSdk = 23
-        targetSdk = 29
-        androidGradlePlugin = "4.0.0"
+        targetSdk = 31
+        androidGradlePlugin = "7.0.2"
         androidMavenGradlePlugin = "2.1"
         dokka = "0.9.18"
         constraintLayout = "2.1.0"
@@ -39,7 +39,7 @@ ext {
         jUnit = "1.1.3"
         rules = "1.4.0"
     }
-    kotlin_version = "1.4.32"
+    kotlin_version = "1.5.30"
     kotlin_reflect = "1.5.0"
     kotlin_coroutines = "1.4.1"
     arcgis = "100.13.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -17,6 +17,6 @@
 #Tue Aug 27 09:42:42 BST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/toolkit-test-app/build.gradle
+++ b/toolkit-test-app/build.gradle
@@ -46,14 +46,14 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility 11
+        targetCompatibility 11
     }
     buildFeatures {
         dataBinding = true
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'

--- a/toolkit-test-app/src/main/AndroidManifest.xml
+++ b/toolkit-test-app/src/main/AndroidManifest.xml
@@ -34,7 +34,8 @@
         <activity
             android:name="com.esri.arcgisruntime.toolkit.test.ToolkitTestAppMainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme">
+            android:theme="@style/AppTheme"
+                android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -66,7 +67,7 @@
         <activity
                 android:name=".popup.PopupViewTestActivity"
                 android:label="@string/arcgis_popup_view_activity_label"
-                android:theme="@style/PopupViewTheme"></activity>
+                android:theme="@style/PopupViewTheme" />
 
     </application>
 


### PR DESCRIPTION
upgrade the Android Gradle plugin from 4.0.0 to 7.0.2

upgrading the plugin forces us to upgrade our compiled SDK version from 29 to 31

upgrading the plugin forces us to upgrade Java Version from 1.8 to 11

upgrading the plugin also wants the URL to be secured http -> https 
'http://olympus.esri.com/artifactory/arcgisruntime-repo/'

